### PR TITLE
Update the blitz article's links 

### DIFF
--- a/_posts/2017-12-06-blitz-preparation.md
+++ b/_posts/2017-12-06-blitz-preparation.md
@@ -12,6 +12,8 @@ author:
 
 ---
 
+_Update: Links to the Blitz registration page were added._
+
 ## A New Competition Appears! And Its Name Is Coveo Blitz
 
 The first time I heard about the Coveo Blitz was through a spam^H^H^H^H email from my school faculty informing me that some company I’d never heard of from Quebec was organizing a coding competition. Having nothing else to do and looking for some way to hone my coding skills, I enlisted my friends to register for the competition as a group. After all, the only requirement they asked for registration was to be able to send an email (something I, [and others apparently](https://blogs.technet.microsoft.com/exchange/2004/04/08/me-too/), still fail to properly do even today).
@@ -46,7 +48,7 @@ Well, you know, I thought [I knew](https://www.youtube.com/watch?v=cphNpqKpKc4).
 
 Before I take a deep dive into the madness that is Coveo Blitz, I’d like to take a moment to underline how AWESOME this kind of event is. It’s been six years and I can still remember all those details from the preparation that preceded the day of the event. On my best days, I can barely remember what I had for lunch a day ago. But Coveo Blitz bucks that forgetfulness and is ingrained as one of those memories you constantly look back on with pride and joy, easily one of my highlights from my college years. I had the chance to develop friendships, meet like-minded passionate devs, got to learn what the heck Coveo is, and truly learn how great the company is. 
 
-Stay tuned for the next post - there, I’ll talk about the big day. Maybe you’ll even pick up some interesting tidbits for you and your team. I mean, if you plan on participating. You are participating, right? 
+Stay tuned for the next post - there, I’ll talk about the big day. Maybe you’ll even pick up some interesting tidbits for you and your team. I mean, if you plan on participating. You are participating, right? If not: [https://blitz.coveo.com](https://blitz.coveo.com).
 
 Andy out
 

--- a/_posts/2018-01-05-blitz-day.md
+++ b/_posts/2018-01-05-blitz-day.md
@@ -12,6 +12,8 @@ author:
 
 ---
 
+_Update: Links to the Blitz registration page were added._
+
 ## Blitzday
 
 Saturday. 7 AM. Normally I’d be sleeping in. But alas, this Saturday is not like your regular Saturday. I’m wide awake and super hyped. No, this isn’t the first chapter of my new fantasy book, it’s real. It’s Blitzday. I’m ready to crush through code like never before.
@@ -107,7 +109,7 @@ Francis managed to get his crawler up and running really quickly, which was an e
 
 Last, but not least: **Enjoy the hell out of it!** I created a stronger bond with my friends, met talented people who I now work with and, this is not negligible, got the chance to write that I participated in such a cool event on my quite empty early-career-resume.
 
-Alright! Off I go, I still have some final touch ups to do on this year’s edition of the Blitz. You did register, right?! If not, make sure to join us next year or to follow the event on our Facebook live stream!
+Alright! Off I go, I still have some final touch ups to do on this year’s edition of the Blitz. [You did register, right](https://blitz.coveo.com)?! If not, make sure to join us next year or to follow the event on our Facebook live stream!
 
 Andy out, Blitz on.
 


### PR DESCRIPTION
Updated the blitz url in the blitz articles.

I've also added an update note to make it clear it's just an update.