### PR TITLE
Change "Training" menu item url to "https://academy.coveo.com/"

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -108,7 +108,7 @@
 					<li><a id="jsSupport" href="https://support.coveo.com"  target="_blank">Support</a></li>
 					<li><a id="jsProductDocs" href="https://docs.coveo.com" target="_blank">Product docs</a></li>
 					<li><a id="jsAnswers" href="https://answers.coveo.com" target="_blank">Answers</a></li>
-					<li><a id="jsTraining" href="https://www.coveo.com/training" target="_blank">Training</a></li>
+					<li><a id="jsTraining" href="https://academy.coveo.com/" target="_blank">Training</a></li>
 					<li><a d="jsTechBlog" href="/"  class="current">Tech Blog</a></li>
 				</ul>
 				<ul class="externalbox with-sub">


### PR DESCRIPTION
This is the change for [CX-113], changed the "Training" menu item url to "https://academy.coveo.com/" from "https://www.coveo.com/training"