### PR TITLE
fix aws cli command in blog post

### DIFF
--- a/_posts/2020-03-26-6-automatic-credentials-rotation.md
+++ b/_posts/2020-03-26-6-automatic-credentials-rotation.md
@@ -53,7 +53,7 @@ Secrets in Secrets Manager have a deletion retention period. This customizable p
 
 This is the result of bad error handling on the provider side and simply means that a secret cannot be recreated when already scheduled for deletion. Running the following CLI command will fix the problem:
 ``
-aws secrets-manager delete-secret --secret-id my-awesome-secret --force-delete-without-recovery
+aws secretsmanager delete-secret --secret-id my-awesome-secret --force-delete-without-recovery
 ``
 
 ## 6. When is a Rotation Triggered?


### PR DESCRIPTION
This command does not work, we need to remove the hyphen from the blog post.

thanks for reviewing :) 